### PR TITLE
feat: enforce authentication on all endpoints

### DIFF
--- a/auth/user-authentication-middleware.go
+++ b/auth/user-authentication-middleware.go
@@ -8,19 +8,10 @@ import (
 	"github.com/plantineers/plantbuddy-server/utils"
 )
 
-// Takes as parameters the function serving the endpoint, the minimum role, an array of functions that are not subject to authentication
-func UserAuthMiddleware(f func(http.ResponseWriter, *http.Request), role Role, unrestrictedMethods []string) http.Handler {
+// Takes as parameters the function serving the endpoint, the minimum role
+func UserAuthMiddleware(f func(http.ResponseWriter, *http.Request), role Role) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		handler := http.HandlerFunc(f)
-
-		// Check if method is unrestricted
-		for _, unrestrictedMethod := range unrestrictedMethods {
-			// Unrestricted methods skip the authentication process
-			if r.Method == unrestrictedMethod {
-				handler.ServeHTTP(w, r)
-				return
-			}
-		}
 
 		user, err := authUser(r)
 		switch err {

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -26,26 +26,26 @@ func main() {
 	plant.InitializeValidator()
 
 	// The POST method is not subject to user authentication as it is used by aggregators to send data
-	http.Handle("/v1/sensor-data", auth.UserAuthMiddleware(sensor.SensorDataHandler, auth.Gardener, []string{"POST"}))
+	http.Handle("/v1/sensor-data", auth.UserAuthMiddleware(sensor.SensorDataHandler, auth.Gardener))
 
-	http.Handle("/v1/sensor-types", auth.UserAuthMiddleware(sensor.SensorTypesHandler, auth.Gardener, []string{}))
+	http.Handle("/v1/sensor-types", auth.UserAuthMiddleware(sensor.SensorTypesHandler, auth.Gardener))
 
-	http.Handle("/v1/controllers", auth.UserAuthMiddleware(controller.ControllersHandler, auth.Gardener, []string{}))
-	http.Handle("/v1/controller/", auth.UserAuthMiddleware(controller.ControllerHandler, auth.Gardener, []string{}))
+	http.Handle("/v1/controllers", auth.UserAuthMiddleware(controller.ControllersHandler, auth.Gardener))
+	http.Handle("/v1/controller/", auth.UserAuthMiddleware(controller.ControllerHandler, auth.Gardener))
 
-	http.Handle("/v1/plants", auth.UserAuthMiddleware(plant.PlantsHandler, auth.Gardener, []string{}))
-	http.Handle("/v1/plants/overview", auth.UserAuthMiddleware(plant.PlantOverviewHandler, auth.Gardener, []string{}))
-	http.Handle("/v1/plant", auth.UserAuthMiddleware(plant.PlantCreateHandler, auth.Gardener, []string{}))
-	http.Handle("/v1/plant/", auth.UserAuthMiddleware(plant.PlantHandler, auth.Gardener, []string{}))
+	http.Handle("/v1/plants", auth.UserAuthMiddleware(plant.PlantsHandler, auth.Gardener))
+	http.Handle("/v1/plants/overview", auth.UserAuthMiddleware(plant.PlantOverviewHandler, auth.Gardener))
+	http.Handle("/v1/plant", auth.UserAuthMiddleware(plant.PlantCreateHandler, auth.Gardener))
+	http.Handle("/v1/plant/", auth.UserAuthMiddleware(plant.PlantHandler, auth.Gardener))
 
-	http.Handle("/v1/plant-groups", auth.UserAuthMiddleware(plant.PlantGroupsHandler, auth.Gardener, []string{}))
-	http.Handle("/v1/plant-groups/overview", auth.UserAuthMiddleware(plant.PlantGroupOverviewHandler, auth.Gardener, []string{}))
-	http.Handle("/v1/plant-group", auth.UserAuthMiddleware(plant.PlantGroupCreateHandler, auth.Gardener, []string{}))
-	http.Handle("/v1/plant-group/", auth.UserAuthMiddleware(plant.PlantGroupHandler, auth.Gardener, []string{}))
+	http.Handle("/v1/plant-groups", auth.UserAuthMiddleware(plant.PlantGroupsHandler, auth.Gardener))
+	http.Handle("/v1/plant-groups/overview", auth.UserAuthMiddleware(plant.PlantGroupOverviewHandler, auth.Gardener))
+	http.Handle("/v1/plant-group", auth.UserAuthMiddleware(plant.PlantGroupCreateHandler, auth.Gardener))
+	http.Handle("/v1/plant-group/", auth.UserAuthMiddleware(plant.PlantGroupHandler, auth.Gardener))
 
-	http.Handle("/v1/users", auth.UserAuthMiddleware(auth.UsersHandler, auth.Admin, []string{}))
-	http.Handle("/v1/user", auth.UserAuthMiddleware(auth.UserCreateHandler, auth.Admin, []string{}))
-	http.Handle("/v1/user/", auth.UserAuthMiddleware(auth.UserHandler, auth.Admin, []string{}))
+	http.Handle("/v1/users", auth.UserAuthMiddleware(auth.UsersHandler, auth.Admin))
+	http.Handle("/v1/user", auth.UserAuthMiddleware(auth.UserCreateHandler, auth.Admin))
+	http.Handle("/v1/user/", auth.UserAuthMiddleware(auth.UserHandler, auth.Admin))
 	http.HandleFunc("/v1/user/login", auth.LoginHandler)
 
 	log.Printf("Server running on port %d", config.PlantBuddyConfig.Port)

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -25,7 +25,6 @@ func main() {
 	// Initialize the validator for the plant package
 	plant.InitializeValidator()
 
-	// The POST method is not subject to user authentication as it is used by aggregators to send data
 	http.Handle("/v1/sensor-data", auth.UserAuthMiddleware(sensor.SensorDataHandler, auth.Gardener))
 
 	http.Handle("/v1/sensor-types", auth.UserAuthMiddleware(sensor.SensorTypesHandler, auth.Gardener))

--- a/server-requests.http
+++ b/server-requests.http
@@ -8,6 +8,7 @@ Authorization: Basic a3J1c2U6SWxvdmVD
 
 ### Save a new sensor data set.
 POST http://localhost:3333/v1/sensor-data
+Authorization: Basic a3J1c2U6SWxvdmVD
 Content-Type: application/json
 
 {


### PR DESCRIPTION
With `POST to /sensor-data` now requiring authorization, there is no need for the ability to exclude certain endpoints anymore